### PR TITLE
Add getter for port number

### DIFF
--- a/src/main/java/org/nikkii/embedhttp/HttpServer.java
+++ b/src/main/java/org/nikkii/embedhttp/HttpServer.java
@@ -135,6 +135,14 @@ public class HttpServer implements Runnable {
 	}
 
 	/**
+	 * Get the port number that the service is listening on. Useful when initializing
+	 * with an automatically-assigned port number.
+	 */
+	public int getPort() {
+		return socket.getLocalPort();
+	}
+
+	/**
 	 * Set a capability
 	 * 
 	 * @param capability


### PR DESCRIPTION
This is useful when starting the server with an automatically-assigned
port number.